### PR TITLE
Fixed mandatory User Agent for Github API 

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -50,8 +50,12 @@ build.url <- function(ctx, req, params)
 api.request <- function(ctx, req, method, expect.code=200, params=list(), config=accept_json())
 {
   url <- build.url(ctx, req, params)
+  #fix for http://developer.github.com/changes/2013-04-24-user-agent-required/
+  config<-c(config, user_agent(getOption("HTTPUserAgent")))
   r <- method(url, config=config)
-  stopifnot(r$status_code %in% expect.code)
+  if(!r$status_code %in% expect.code)
+    #meanigful error for API, to manage future API changes
+    stop(paste("Unexpected Github API response - \n",r), call.=FALSE)
   r
 }
 


### PR DESCRIPTION
Github has made it mandatory for API requests to be accompanied with a meaningful User Agent header. 
http://developer.github.com/changes/2013-04-24-user-agent-required/
Also logging response in case of API failures - will make it easier to manage API changes.
