### PR TITLE
Fix for user-agent in api.request.body

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -71,7 +71,8 @@ api.request.with.body <- function(ctx, req, method, expect.code=200, params=list
   url <- build.url(ctx, req, params)
   cat(url)
   cat(body)
-  
+  #fix for http://developer.github.com/changes/2013-04-24-user-agent-required/
+  config<-c(config, user_agent(getOption("HTTPUserAgent")))
   r = method(url, config=config, body=body)
   if(!r$status_code %in% expect.code)
     #meaningful error for API, to manage future API changes


### PR DESCRIPTION
Github API v3 expects a valid user agent. This resolves the problem.
