### PR TITLE
Specify Github API version explicitly

### DIFF
--- a/R/github.R
+++ b/R/github.R
@@ -180,7 +180,7 @@ get.github.context <- function()
 {
   resource <- str_c(req, collapse = '/')
   url <- .build.url(ctx, resource, params)
-  config <- c(config, user_agent(getOption("HTTPUserAgent")))
+  config <- c(config, user_agent(getOption("HTTPUserAgent")), add_headers(Accept = "application/vnd.github.beta+json"))
 
   r <- method(url = url, config = config, body = body)
   result <- tryCatch(content(r),


### PR DESCRIPTION
Please see http://developer.github.com/v3/versions/ . From March 15, 2014 the Github API default will switch to `v3` from `beta`. This will break a few things in RCloud, for which the detailed list is here. http://developer.github.com/v3/versions/#differences-from-beta-version 

The proposed change ensures that we explicitly provide `beta` as a specific version until we are ready to move to `v3`.
