### PR TITLE
FIX #25 : replaced .api.patch.request with .api.delete.request

### DIFF
--- a/R/gists.R
+++ b/R/gists.R
@@ -161,4 +161,4 @@ modify.gist.comment <- function(gist.id, comment.id, content, ctx = get.github.c
 #'
 #' @return none
 delete.gist.comment <- function(gist.id, comment.id, ctx = get.github.context())
-  .api.patch.request(ctx, c("gists", gist.id, "comments", comment.id))
+  .api.delete.request(ctx, c("gists", gist.id, "comments", comment.id))


### PR DESCRIPTION
replaced .api.patch.request with .api.delete.request. In reference to rcloud issue #384.
https://github.com/att/rcloud/issues/384
