### PR TITLE
Make code in inst/tests/test_basic.r much faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 *~
+rgithub.Rproj

--- a/inst/tests/test_basic.r
+++ b/inst/tests/test_basic.r
@@ -1,13 +1,13 @@
 context("Basic Tests")
 
 test_that("A basic rgithub context can be acquired", {
-	create.github.context("https://api.github.com")
-	repos <- get.user.repositories("cscheid")
-	repos_overview <- do.call("rbind",
-														lapply(repos$content[1:5], function(x) {
-															data.frame(name = x$name,
-																				 owner = x$owner$login,
-																				 updated_at = x$updated_at)}))
-	cat("\n")
-	print(repos_overview)
+  create.github.context("https://api.github.com")
+  repos <- get.user.repositories("cscheid")
+  repos_overview <- do.call("rbind",
+                            lapply(repos$content[1:5], function(x) {
+                              data.frame(name = x$name,
+                                         owner = x$owner$login,
+                                         updated_at = x$updated_at)}))
+  cat("\n")
+  print(repos_overview)
 })

--- a/inst/tests/test_basic.r
+++ b/inst/tests/test_basic.r
@@ -1,7 +1,13 @@
 context("Basic Tests")
 
 test_that("A basic rgithub context can be acquired", {
-  create.github.context("https://api.github.com")
-  repos <- get.user.repositories("cscheid")
-  print(repos)
+	create.github.context("https://api.github.com")
+	repos <- get.user.repositories("cscheid")
+	repos_overview <- do.call("rbind",
+														lapply(repos$content[1:5], function(x) {
+															data.frame(name = x$name,
+																				 owner = x$owner$login,
+																				 updated_at = x$updated_at)}))
+	cat("\n")
+	print(repos_overview)
 })


### PR DESCRIPTION
This could be the first of many pull requests, so I want to make sure I'm starting from a happy place w/r/t testing the package. The existing code in `test_basic.r` takes a really long time to run. The version in this PR is much faster and easier on the eyes.

Since there are no expectations, I think this makes the code no more or less effective as a test.

The addition to `.gitignore` would help anyone contributing who uses RStudio.