### PR TITLE
use new endpoint for adding members to an organization/team

### DIFF
--- a/R/orgs.R
+++ b/R/orgs.R
@@ -210,7 +210,7 @@ is.member.in.team <- function(id, user, ctx = get.github.context())
 #'
 #' @return TRUE if user is member of team
 add.member.to.team <- function(id, user, ctx = get.github.context())
-  .api.put.request(ctx, c("teams", id, "members", user), expect.code=204)
+  .api.put.request(ctx, c("teams", id, "memberships", user))
 
 #' remove member from team
 #'


### PR DESCRIPTION
In August 2014 GitHub announced a breaking change to the API for how organization owners add new members to their organization:

https://developer.github.com/changes/2014-08-05-team-memberships-api/

That has come into full effect now.

Here's the deprecation notice in the context of API documentation:

https://developer.github.com/v3/orgs/teams/#get-team-member

And here's how things should be done now (which I do in this PR):

https://developer.github.com/v3/orgs/teams/#get-team-membership

This affects other functions that relate to Teams and Organizations, so I plan to make more PRs as I work with those functions and can verify how they should change.

If I try to add someone to a Team within an Organization and they are not yet a member of any Team within the Organization, the existing `add.member.to.team()` function fails and does not trigger an invitation to join the Team/Organization:

```r
> add.member.to.team(id = <blahblah>, user = <blahblah>)
$ok
[1] FALSE

$content
$content$message
[1] "User isn't a member of this organization. Please invite them first."

$content$errors
$content$errors[[1]]
$content$errors[[1]]$code
[1] "unaffiliated"

$content$errors[[1]]$field
[1] "user"

$content$errors[[1]]$resource
[1] "TeamMember"



$content$documentation_url
[1] "https://developer.github.com/v3/orgs/teams/#add-team-membership"


$headers
$server
[1] "GitHub.com"

$date
[1] "Tue, 13 Jan 2015 23:30:08 GMT"

$`content-type`
[1] "application/json; charset=utf-8"

$`content-length`
[1] "241"

$status
[1] "422 Unprocessable Entity"

$`x-ratelimit-limit`
[1] "5000"

$`x-ratelimit-remaining`
[1] "4996"

$`x-ratelimit-reset`
[1] "1421193756"

$`x-oauth-scopes`
[1] "admin:org, admin:public_key, admin:repo_hook, delete_repo, gist, notifications, repo, user"

$`x-accepted-oauth-scopes`
[1] "admin:org, repo"

$`x-github-media-type`
[1] "github.beta; format=json"

$`x-xss-protection`
[1] "1; mode=block"

$`x-frame-options`
[1] "deny"

$`content-security-policy`
[1] "default-src 'none'"

$`access-control-allow-credentials`
[1] "true"

$`access-control-expose-headers`
[1] "ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval"

$`access-control-allow-origin`
[1] "*"

$`x-github-request-id`
[1] "ACDAAC5B:3E45:F42681:54B5AA7F"

$`strict-transport-security`
[1] "max-age=31536000; includeSubdomains; preload"

$`x-content-type-options`
[1] "nosniff"

attr(,"class")
[1] "insensitive" "list"       

$code
[1] 422
```