### PR TITLE
comply with current recommended structure for tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,4 @@
 library(testthat)
 library(github)
 
-test_package("github")
+test_check("github")

--- a/tests/testthat/test_basic.r
+++ b/tests/testthat/test_basic.r
@@ -1,3 +1,4 @@
+library(github)
 context("Basic Tests")
 
 test_that("A basic rgithub context can be acquired", {

--- a/tests/testthat/test_basic.r
+++ b/tests/testthat/test_basic.r
@@ -1,4 +1,3 @@
-library(github)
 context("Basic Tests")
 
 test_that("A basic rgithub context can be acquired", {


### PR DESCRIPTION
A while ago the testthat package switched to a different folder/file structure. This PR just complies with that before any new tests get added.

https://github.com/hadley/testthat/blob/master/NEWS.md#testthat-08