### PR TITLE
add get.gist.forks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: github
 Type: Package
 Title: github API
-Version: 0.9.7
+Version: 0.9.8
 Author: Carlos Scheidegger <cscheid@research.att.com>
 Maintainer: Carlos Scheidegger <cscheid@research.att.com>
 Description: Provides access to the Github v3 API

--- a/R/gists.R
+++ b/R/gists.R
@@ -68,6 +68,16 @@ is.starred <- function(id, ctx = get.github.context())
 fork.gist <- function(id, ctx = get.github.context())
   .api.post.request  (ctx, c("gists", id, "forks"))
 
+#' list the forks of a gist
+#'
+#' @param id the gist id
+#'
+#' @param ctx the github context object
+#'
+#' @return the list of fork information
+get.gist.forks <- function(id, ctx = get.github.context())
+  .api.get.request  (ctx, c("gists", id, "forks"))
+
 #' delete a gist
 #'
 #' @param id the gist id


### PR DESCRIPTION
Hi @cscheid!

this was probably missed because it's the same URL as forking but a get instead of a push.

We're finally implementing a "most popular notebooks" feature. (This is the most basic and base recommendation imaginable, but hey, it's a start.)

I have tested this within RCloud.