### PR TITLE
set Content-Type for POST requests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: github
 Type: Package
 Title: github API
-Version: 0.9.8
+Version: 0.9.9
 Author: Carlos Scheidegger <cscheid@research.att.com>
 Maintainer: Carlos Scheidegger <cscheid@research.att.com>
 Description: Provides access to the Github v3 API

--- a/R/gists.R
+++ b/R/gists.R
@@ -145,7 +145,7 @@ get.gist.comment <- function(gist.id, comment.id, ctx = get.github.context())
 #'
 #' @return the comment
 create.gist.comment <- function(gist.id, content, ctx = get.github.context())
-  .api.post.request(ctx, c("gists", gist.id, "comments"), body=content, config=add_headers(Accept='application/vnd.github.v3.text+json'))
+  .api.post.request(ctx, c("gists", gist.id, "comments"), body=content, config=add_headers(Accept='application/vnd.github.v3.text+json', `Content-Type` = 'application/json'))
 
 #' Edit gist comment
 #'
@@ -159,7 +159,7 @@ create.gist.comment <- function(gist.id, content, ctx = get.github.context())
 #'
 #' @return the comment
 modify.gist.comment <- function(gist.id, comment.id, content, ctx = get.github.context())
-  .api.patch.request(ctx, c("gists", gist.id, "comments", comment.id), body=content, config=add_headers(Accept='application/vnd.github.v3.text+json'))
+  .api.patch.request(ctx, c("gists", gist.id, "comments", comment.id), body=content, config=add_headers(Accept='application/vnd.github.v3.text+json', `Content-Type` = 'application/json'))
 
 #' Delete gist comment
 #'

--- a/R/github.R
+++ b/R/github.R
@@ -247,6 +247,7 @@ get.github.context <- function()
   if (ctx$verbose)
     config <- c(config, verbose())
 
+  # Rserve::ulog("GITHUB request: ", url)
   r <- method(url = url, config = config, body = body)
   result <- tryCatch(content(r),
                      error = function(e) {
@@ -272,6 +273,7 @@ get.github.context <- function()
     if (is.list(body)) {
       body <- toJSON(body, auto_unbox=TRUE, null="null")
       # config = c(config, add_headers(`Content-Type` = "application/json; charset=utf-8"))
+      config = c(config, content_type("application/json; charset=utf-8"))
     }
     else if (is.character(body))
       stopifnot(length(body) == 1)


### PR DESCRIPTION
POST request need to declare JSON payload in Content-Type in order to be correctly recognized by some back-ends.